### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Docker Automated buil](https://img.shields.io/docker/automated/faph/hugo-box.svg?maxAge=2592000)](https://hub.docker.com/r/faph/hugo-box/)
+[![Docker Automated buil](https://img.shields.io/docker/automated/faph/hugo-box.svg?maxAge=2592000)](https://hub.docker.com/r/faph/hugo-box/) [![](https://images.microbadger.com/badges/image/faph/hugo-box.svg)](https://microbadger.com/images/faph/hugo-box "Get your own image badge on microbadger.com")
 
 # Hugo Box
 
@@ -45,3 +45,4 @@ publish:
 Released under the [MIT License (MIT)](LICENSE).
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [faph/hugo-box](https://hub.docker.com/r/faph/hugo-box/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/faph/hugo-box).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/faph/hugo-box.svg)](https://microbadger.com/images/faph/hugo-box "Get your own image badge on microbadger.com")
